### PR TITLE
Fix double quote escaping bug

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -112,11 +112,11 @@ var convertParametersInner = function(convertString, param) {
             tempParamKey = tempParamKey.toString();
           }
 
-          tempParamKey = tempParamKey.replace(/\\/g, '\\\\\\\\').replace(/'/g, '\\\'').replace(/\$/g, '$$$$');
+          tempParamKey = tempParamKey.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\$/g, '$$$$');
           convertString = convertString.replace(reg, "'" + tempParamKey + "'");
         } else if (prefix === '$') {
           if(typeof tempParamKey === 'string') {
-            tempParamKey = tempParamKey.replace(/\\/g, '\\\\\\\\').replace(/\$/g, '$$$$');
+            tempParamKey = tempParamKey.replace(/\\/g, '\\\\').replace(/\$/g, '$$$$');
           }
           convertString = convertString.replace(reg, tempParamKey);
         }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -109,7 +109,7 @@ var convertParametersInner = function(convertString, param) {
           if (isObject(tempParamKey) || isArray(tempParamKey)) {
             tempParamKey = JSON.stringify(tempParamKey);
           } else {
-            tempParamKey = tempParamKey.toString().replace(/"/g, '\\\"');
+            tempParamKey = tempParamKey.toString();
           }
 
           tempParamKey = tempParamKey.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\$/g, '$$$$');

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -49,7 +49,7 @@ var convertParameters = function(children, param) {
   try{
     convertString = convertParametersInner(convertString, param);
   } catch (err) {
-    throw new Error("Error occurred during convert parameters.");
+    throw new Error(err.message || "Error occurred during convert parameters.");
   }
   
   try{

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -112,11 +112,11 @@ var convertParametersInner = function(convertString, param) {
             tempParamKey = tempParamKey.toString();
           }
 
-          tempParamKey = tempParamKey.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\$/g, '$$$$');
+          tempParamKey = tempParamKey.replace(/\\/g, '\\\\\\\\').replace(/'/g, '\\\'').replace(/\$/g, '$$$$');
           convertString = convertString.replace(reg, "'" + tempParamKey + "'");
         } else if (prefix === '$') {
           if(typeof tempParamKey === 'string') {
-            tempParamKey = tempParamKey.replace(/\\/g, '\\\\').replace(/\$/g, '$$$$');
+            tempParamKey = tempParamKey.replace(/\\/g, '\\\\\\\\').replace(/\$/g, '$$$$');
           }
           convertString = convertString.replace(reg, tempParamKey);
         }


### PR DESCRIPTION
## ❓ 작업 배경
mybatis-mapper 가 double quote(") 에 backslash(\) 를 붙이는 버그가 존재하고 있어 이를 수정하였습니다.
이 repository 는 public repository 라 PR 도 공개입니다. 따라서 JIRA 이슈 등의 내부 링크들은 포함하지 않습니다.

## ✏️ 변경사항
- 불필요한 double quote 의 escaping 을 제거 했습니다.
- SQL 에서의 backslash 하나의 표현을 위해서는 모두 4개의 backslash가 필요한데, backslash 2개로 escape 하고 있어 이도 역시 수정 했습니다.
- mapper 의 바깥 scope 에서 뭉뚱그려진 error message 로 exception message 를 표현하여 문제 발생 시 추적하기가 힘들어 inner scope 의 exception 의 error message 가 있으면 그대로 사용하도록 변경했습니다.

## ⚡ 변경에 의한 영향
- mybatis-mapper 의 templating 에 의해 변환되는 모든 query 들이 영향을 받습니다.